### PR TITLE
Fix for flaky test in ConjoinStepTest file

### DIFF
--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
@@ -36,9 +36,7 @@ import static org.junit.Assert.fail;
 
 public class ConjoinStepTest extends StepTest {
     @Override
-    protected List<Traversal> getTraversals() {
-        return Collections.singletonList(__.conjoin("a"));
-    }
+    protected List<Traversal> getTraversals() { return Collections.singletonList(__.conjoin("a")); }
 
     @Test
     public void testReturnTypes() {
@@ -50,15 +48,13 @@ public class ConjoinStepTest extends StepTest {
         }
 
         assertEquals("", __.__(Collections.emptyList()).conjoin("a").next());
-        assertEquals("5AA8AA10", __.__(new long[] { 5L, 8L, 10L }).conjoin("AA").next());
-        assertEquals("715", __.__(1).constant(new Long[] { 7L, 15L }).conjoin("").next());
-        assertEquals("5.5,8.0,10.1", __.__(new double[] { 5.5, 8.0, 10.1 }).conjoin(",").next());
+        assertEquals("5AA8AA10", __.__(new long[] {5L, 8L, 10L}).conjoin("AA").next());
+        assertEquals("715", __.__(1).constant(new Long[] {7L, 15L}).conjoin("").next());
+        assertEquals("5.5,8.0,10.1", __.__(new double[] {5.5, 8.0, 10.1}).conjoin(",").next());
         assertNull(__.__(Arrays.asList(null, null)).conjoin(",").next());
 
         final Set<Integer> set = new LinkedHashSet<>();
-        set.add(10);
-        set.add(11);
-        set.add(12);
+        set.add(10); set.add(11); set.add(12);
         assertEquals("10.11.12", __.__(set).conjoin(".").next());
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -36,7 +36,9 @@ import static org.junit.Assert.fail;
 
 public class ConjoinStepTest extends StepTest {
     @Override
-    protected List<Traversal> getTraversals() { return Collections.singletonList(__.conjoin("a")); }
+    protected List<Traversal> getTraversals() {
+        return Collections.singletonList(__.conjoin("a"));
+    }
 
     @Test
     public void testReturnTypes() {
@@ -48,13 +50,15 @@ public class ConjoinStepTest extends StepTest {
         }
 
         assertEquals("", __.__(Collections.emptyList()).conjoin("a").next());
-        assertEquals("5AA8AA10", __.__(new long[] {5L, 8L, 10L}).conjoin("AA").next());
-        assertEquals("715", __.__(1).constant(new Long[] {7L, 15L}).conjoin("").next());
-        assertEquals("5.5,8.0,10.1", __.__(new double[] {5.5, 8.0, 10.1}).conjoin(",").next());
+        assertEquals("5AA8AA10", __.__(new long[] { 5L, 8L, 10L }).conjoin("AA").next());
+        assertEquals("715", __.__(1).constant(new Long[] { 7L, 15L }).conjoin("").next());
+        assertEquals("5.5,8.0,10.1", __.__(new double[] { 5.5, 8.0, 10.1 }).conjoin(",").next());
         assertNull(__.__(Arrays.asList(null, null)).conjoin(",").next());
 
-        final Set<Integer> set = new HashSet<>();
-        set.add(10); set.add(11); set.add(12);
+        final Set<Integer> set = new LinkedHashSet<>();
+        set.add(10);
+        set.add(11);
+        set.add(12);
         assertEquals("10.11.12", __.__(set).conjoin(".").next());
     }
 }


### PR DESCRIPTION
## What is the purpose of this PR
- This PR fixes the error resulting from flaky test: `org.apache.tinkerpop.gremlin.process.traversal.step.map.ConjoinStepTest.testReturnTypes`
- The mentioned tests may fail or pass without changes made to the source code when it is run in different JVMs due to HashSet's non-deterministic iteration order.

## Why the tests fail

The tests failed due to the unpredictable ordering of elements in a `HashSet`, causing inconsistent outcomes. Switching to `LinkedHashSet` fixed this by ensuring a stable element order.

## Reproduce the test failure
running the following command uses NonDex to reveal a potential failure of the toStringTest method

`mvn -pl gremlin-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRunsWithoutShuffling=10 -Dtest='org.apache.tinkerpop.gremlin.process.traversal.step.map.ConjoinStepTest#testReturnTypes'`

## Expected results

- Test should run successfully when run with `NonDex`

## Actual Result

- We get the following failure for the test `org.apache.tinkerpop.gremlin.process.traversal.step.map.ConjoinStepTest.testReturnTypes`
`ConjoinStepTest.testReturnTypes:58 expected: <1 [0.11.12]> but was:<1[1.12.10]>[ERROR]:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0 Surefire failed when running tests for aRJJ2d+KeIRTGZK9KBGbsvXC6VB0F0Hj3Gv1681T0Us=`


## Fix

- Changed the object type of testReturnTypes from **HashSet** to **LinkedHashSet** in method `org.apache.tinkerpop.gremlin.process.traversal.step.map.ConjoinStepTest.testReturnTypes`

